### PR TITLE
Add support for @itemprop="mainEntity" top-level items

### DIFF
--- a/src/Reader/MicrodataReader.php
+++ b/src/Reader/MicrodataReader.php
@@ -31,11 +31,12 @@ class MicrodataReader implements Reader
         $xpath = new DOMXPath($document);
 
         /**
-         * An item is a top-level Microdata item if its element does not have an itemprop attribute.
+         * An item is a top-level Microdata item if its element does not have an itemprop attribute or
+		 * if it is the mainEntity of the page.
          *
          * https://www.w3.org/TR/microdata/#associating-names-with-items
          */
-        $nodes = $xpath->query('//*[@itemscope and not(@itemprop)]');
+        $nodes = $xpath->query('//*[@itemscope and (not(@itemprop) or @itemprop="mainEntity")]');
         $nodes = iterator_to_array($nodes);
 
         return array_map(function(DOMNode $node) use ($xpath, $url) {


### PR DESCRIPTION
An entity with `@itemprop="mainEntity"` is also a top-level entity (the primary entity described in the page), per: https://schema.org/mainEntity

If this is not something you want to support in the library, let me know and I'll add a (private) fork to our package repo instead.