### PR TITLE
Fix for JsonLD Reader not detecting when "@type" was an Array

### DIFF
--- a/src/Reader/JsonLdReader.php
+++ b/src/Reader/JsonLdReader.php
@@ -150,7 +150,7 @@ class JsonLdReader implements Reader
             } elseif (is_array($type)) {
                 $types = array_map(function($type) use ($vocabulary) {
                     return is_string($type) ? $this->resolveTerm($type, $vocabulary) : null;
-                }, $types);
+                }, $type);
 
                 $types = array_filter($types);
                 $types = array_values($types);


### PR DESCRIPTION
This PR solves a small typo in JsonLDReader class that was preventing to read items with `@type` as Array.

` "@type": ["Offer", "PriceSpecification"]`

https://w3c.github.io/json-ld-syntax/#specifying-the-type