### PR TITLE
Add compatibility with PHP 8.4 Dom\HTMLDocument

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "phpunit/phpunit": "^8.0 || ^9.0",
     "php-coveralls/php-coveralls": "^2.0",
-    "vimeo/psalm": "6.12.0"
+    "vimeo/psalm": "6.13.1"
   },
   "autoload": {
     "psr-4": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,36 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.12.0@cf420941d061a57050b6c468ef2c778faf40aee2">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+  <file src="src/DOMBuilder.php">
+    <MixedReturnStatement>
+      <code><![CDATA[HTMLDocument::createFromFile($file, LIBXML_NOERROR | HTML_NO_DEFAULT_NS)]]></code>
+      <code><![CDATA[HTMLDocument::createFromString($html, LIBXML_NOERROR | HTML_NO_DEFAULT_NS)]]></code>
+    </MixedReturnStatement>
+  </file>
   <file src="src/Reader/JsonLdReader.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$data]]></code>
-      <code><![CDATA[$item]]></code>
-      <code><![CDATA[$value]]></code>
-    </ArgumentTypeCoercion>
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($type)]]></code>
-    </DocblockTypeContradiction>
-    <MissingClosureParamType>
-      <code><![CDATA[$a]]></code>
-    </MissingClosureParamType>
     <MixedArgument>
       <code><![CDATA[$name]]></code>
+      <code><![CDATA[$node->textContent]]></code>
+      <code><![CDATA[$nodes]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$name[0]]]></code>
     </MixedArrayAccess>
+    <MixedMethodCall>
+      <code><![CDATA[$nodes]]></code>
+    </MixedMethodCall>
     <PossiblyInvalidArgument>
-      <code><![CDATA[fn (DOMNode $node) => $this->readJson($node->textContent, $url)]]></code>
+      <code><![CDATA[fn (DOMNode|Node $node) => $this->readJson($node->textContent, $url)]]></code>
     </PossiblyInvalidArgument>
-    <RawObjectIteration>
-      <code><![CDATA[$item]]></code>
-    </RawObjectIteration>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[null]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Reader/MicrodataReader.php">
     <InvalidArgument>
-      <code><![CDATA[function (DOMNode $itemprop) use ($node, $xpath) {
+      <code><![CDATA[function (DOMNode|Node $itemprop) use ($node) {
             for (; ;) {
                 $itemprop = $itemprop->parentNode;
 
@@ -44,9 +38,57 @@
             }
         }]]></code>
     </InvalidArgument>
+    <MixedArgument>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$itemid->textContent]]></code>
+      <code><![CDATA[$itemprops]]></code>
+      <code><![CDATA[$itemtype->textContent]]></code>
+      <code><![CDATA[$names]]></code>
+      <code><![CDATA[$node->textContent]]></code>
+      <code><![CDATA[$nodes]]></code>
+    </MixedArgument>
+    <MixedMethodCall>
+      <code><![CDATA[$itemprops]]></code>
+      <code><![CDATA[$nodes]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[isSameNode]]></code>
+    </MixedMethodCall>
+    <MixedPropertyFetch>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$itemid->textContent]]></code>
+      <code><![CDATA[$itemprop->attributes]]></code>
+      <code><![CDATA[$itemprop->attributes->getNamedItem('itemprop')->textContent]]></code>
+      <code><![CDATA[$itemprop->parentNode]]></code>
+      <code><![CDATA[$itemtype->textContent]]></code>
+    </MixedPropertyFetch>
+    <MixedReturnStatement>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+    </MixedReturnStatement>
     <PossiblyInvalidArgument>
-      <code><![CDATA[fn (DOMNode $node) => $this->nodeToItem($node, $xpath, $url)]]></code>
-      <code><![CDATA[function (DOMNode $itemprop) use ($node, $xpath) {
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[fn (DOMNode|Node $node) => $this->nodeToItem($node, $xpath, $url)]]></code>
+      <code><![CDATA[function (DOMNode|Node $itemprop) use ($node) {
             for (; ;) {
                 $itemprop = $itemprop->parentNode;
 
@@ -59,25 +101,29 @@
                 }
             }
         }]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$names]]></code>
       <code><![CDATA[preg_replace('/\s+/', ' ', $node->textContent)]]></code>
-    </PossiblyNullArgument>
+    </PossiblyInvalidArgument>
     <PossiblyNullPropertyFetch>
-      <code><![CDATA[$itemprop->attributes->getNamedItem('itemprop')->textContent]]></code>
+      <code><![CDATA[$itemprop->attributes]]></code>
+      <code><![CDATA[$itemprop->parentNode]]></code>
     </PossiblyNullPropertyFetch>
     <PossiblyNullReference>
       <code><![CDATA[getNamedItem]]></code>
-      <code><![CDATA[getNamedItem]]></code>
-      <code><![CDATA[getNamedItem]]></code>
-      <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[isSameNode]]></code>
     </PossiblyNullReference>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[$itemprop->attributes->getNamedItem('itemscope')]]></code>
+      <code><![CDATA[$itemprop->isSameNode($node)]]></code>
+    </RiskyTruthyFalsyComparison>
+    <UndefinedPropertyFetch>
+      <code><![CDATA[$itemprop->attributes]]></code>
+      <code><![CDATA[$node->attributes]]></code>
+      <code><![CDATA[$node->attributes]]></code>
+    </UndefinedPropertyFetch>
   </file>
   <file src="src/Reader/RdfaLiteReader.php">
     <InvalidArgument>
-      <code><![CDATA[function (DOMNode $itemprop) use ($node, $xpath) {
+      <code><![CDATA[function (DOMNode|Node $itemprop) use ($node) {
             for (; ;) {
                 $itemprop = $itemprop->parentNode;
 
@@ -89,46 +135,84 @@
                     return false;
                 }
             }
-
-            // Unreachable, but makes static analysis happy
-            return false;
         }]]></code>
     </InvalidArgument>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[fn (DOMNode $node) => $this->nodeToItem($node, $xpath, $url, self::PREDEFINED_PREFIXES, null)]]></code>
-      <code><![CDATA[function (DOMNode $itemprop) use ($node, $xpath) {
-            for (; ;) {
-                $itemprop = $itemprop->parentNode;
-
-                if ($itemprop->isSameNode($node)) {
-                    return true;
-                }
-
-                if ($itemprop->attributes->getNamedItem('typeof')) {
-                    return false;
-                }
-            }
-
-            // Unreachable, but makes static analysis happy
-            return false;
-        }]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
+    <MixedArgument>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
       <code><![CDATA[$names]]></code>
+      <code><![CDATA[$node->textContent]]></code>
+      <code><![CDATA[$nodes]]></code>
+      <code><![CDATA[$properties]]></code>
+      <code><![CDATA[$resource->textContent]]></code>
       <code><![CDATA[$typeof->textContent]]></code>
-      <code><![CDATA[preg_replace('/\s+/', ' ', $node->textContent)]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullPropertyFetch>
-      <code><![CDATA[$property->attributes->getNamedItem('property')->textContent]]></code>
-      <code><![CDATA[$typeof->textContent]]></code>
-    </PossiblyNullPropertyFetch>
-    <PossiblyNullReference>
+      <code><![CDATA[$vocab->textContent]]></code>
+    </MixedArgument>
+    <MixedMethodCall>
+      <code><![CDATA[$nodes]]></code>
+      <code><![CDATA[$properties]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[getNamedItem]]></code>
       <code><![CDATA[isSameNode]]></code>
+    </MixedMethodCall>
+    <MixedPropertyFetch>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$attr->textContent]]></code>
+      <code><![CDATA[$itemprop->attributes]]></code>
+      <code><![CDATA[$itemprop->parentNode]]></code>
+      <code><![CDATA[$property->attributes->getNamedItem('property')->textContent]]></code>
+      <code><![CDATA[$resource->textContent]]></code>
+      <code><![CDATA[$typeof->textContent]]></code>
+      <code><![CDATA[$vocab->textContent]]></code>
+    </MixedPropertyFetch>
+    <MixedReturnStatement>
+      <code><![CDATA[$attr->textContent]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[fn (DOMNode|Node $node) => $this->nodeToItem($node, $xpath, $url, self::PREDEFINED_PREFIXES, null)]]></code>
+      <code><![CDATA[function (DOMNode|Node $itemprop) use ($node) {
+            for (; ;) {
+                $itemprop = $itemprop->parentNode;
+
+                if ($itemprop->isSameNode($node)) {
+                    return true;
+                }
+
+                if ($itemprop->attributes->getNamedItem('typeof')) {
+                    return false;
+                }
+            }
+        }]]></code>
+      <code><![CDATA[preg_replace('/\s+/', ' ', $node->textContent)]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$itemprop->attributes]]></code>
+      <code><![CDATA[$itemprop->parentNode]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
+      <code><![CDATA[getNamedItem]]></code>
+      <code><![CDATA[isSameNode]]></code>
     </PossiblyNullReference>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[$itemprop->attributes->getNamedItem('typeof')]]></code>
+      <code><![CDATA[$itemprop->isSameNode($node)]]></code>
+    </RiskyTruthyFalsyComparison>
+    <UndefinedPropertyFetch>
+      <code><![CDATA[$node->attributes]]></code>
+      <code><![CDATA[$node->attributes]]></code>
+      <code><![CDATA[$node->attributes]]></code>
+      <code><![CDATA[$property->attributes]]></code>
+    </UndefinedPropertyFetch>
   </file>
 </files>

--- a/src/DOMBuilder.php
+++ b/src/DOMBuilder.php
@@ -4,18 +4,27 @@ declare(strict_types=1);
 
 namespace Brick\StructuredData;
 
+use Dom\Document;
+use Dom\HTMLDocument;
 use DOMDocument;
 
+use function class_exists;
+
+use const Dom\HTML_NO_DEFAULT_NS;
 use const LIBXML_NOERROR;
 use const LIBXML_NOWARNING;
 
 final class DOMBuilder
 {
     /**
-     * Builds a DOMDocument from an HTML string.
+     * Builds a (DOM)Document from an HTML string.
      */
-    public static function fromHTML(string $html): DOMDocument
+    public static function fromHTML(string $html): Document|DOMDocument
     {
+        if (class_exists(HTMLDocument::class)) {
+            return HTMLDocument::createFromString($html, LIBXML_NOERROR | HTML_NO_DEFAULT_NS);
+        }
+
         $document = new DOMDocument();
         $document->loadHTML($html, LIBXML_NOWARNING | LIBXML_NOERROR);
 
@@ -23,10 +32,14 @@ final class DOMBuilder
     }
 
     /**
-     * Builds a DOMDocument from an HTML file.
+     * Builds a (DOM)Document from an HTML file.
      */
-    public static function fromHTMLFile(string $file): DOMDocument
+    public static function fromHTMLFile(string $file): Document|DOMDocument
     {
+        if (class_exists(HTMLDocument::class)) {
+            return HTMLDocument::createFromFile($file, LIBXML_NOERROR | HTML_NO_DEFAULT_NS);
+        }
+
         $document = new DOMDocument();
         $document->loadHTMLFile($file, LIBXML_NOWARNING | LIBXML_NOERROR);
 

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\StructuredData;
 
+use Dom\Document;
 use DOMDocument;
 
 /**
@@ -14,11 +15,11 @@ interface Reader
     /**
      * Reads the items contained in the given document.
      *
-     * @param DOMDocument $document The DOM document to read.
-     * @param string      $url      The URL the document was retrieved from. This will be used only to resolve relative
-     *                              URLs in property values. The implementation must not attempt to connect to this URL.
+     * @param Document|DOMDocument $document The (DOM)Document to read.
+     * @param string               $url      The URL the document was retrieved from. This will be used only to resolve relative
+     *                                       URLs in property values. The implementation must not attempt to connect to this URL.
      *
      * @return Item[] The top-level items.
      */
-    public function read(DOMDocument $document, string $url): array;
+    public function read(Document|DOMDocument $document, string $url): array;
 }

--- a/src/Reader/JsonLdReader.php
+++ b/src/Reader/JsonLdReader.php
@@ -162,7 +162,7 @@ final class JsonLdReader implements Reader
             } elseif (is_array($type)) {
                 $types = array_map(
                     fn ($type) => is_string($type) ? $this->resolveTerm($type, $vocabulary) : null,
-                    $types,
+                    $type,
                 );
 
                 $types = array_filter($types);

--- a/src/Reader/MicrodataReader.php
+++ b/src/Reader/MicrodataReader.php
@@ -106,7 +106,7 @@ final class MicrodataReader implements Reader
 
         // Exclude properties that are inside a nested item; XPath does not seem to provide a way to do this.
         // See: https://stackoverflow.com/q/26365495/759866
-        $itemprops = array_filter($itemprops, function (DOMNode $itemprop) use ($node, $xpath) {
+        $itemprops = array_filter($itemprops, function (DOMNode $itemprop) use ($node) {
             for (; ;) {
                 $itemprop = $itemprop->parentNode;
 

--- a/src/Reader/MicrodataReader.php
+++ b/src/Reader/MicrodataReader.php
@@ -6,6 +6,9 @@ namespace Brick\StructuredData\Reader;
 
 use Brick\StructuredData\Item;
 use Brick\StructuredData\Reader;
+use Dom\Document;
+use Dom\Node;
+use Dom\XPath;
 use DOMDocument;
 use DOMNode;
 use DOMXPath;
@@ -15,6 +18,8 @@ use Sabre\Uri\InvalidUriException;
 use function array_filter;
 use function array_map;
 use function array_values;
+use function assert;
+use function class_exists;
 use function explode;
 use function in_array;
 use function iterator_to_array;
@@ -36,9 +41,14 @@ use function trim;
 final class MicrodataReader implements Reader
 {
     #[Override]
-    public function read(DOMDocument $document, string $url): array
+    public function read(Document|DOMDocument $document, string $url): array
     {
-        $xpath = new DOMXPath($document);
+        if ($document instanceof Document) {
+            assert(class_exists(XPath::class));
+            $xpath = new XPath($document);
+        } else {
+            $xpath = new DOMXPath($document);
+        }
 
         /**
          * An item is a top-level Microdata item if its element does not have an itemprop attribute.
@@ -49,19 +59,19 @@ final class MicrodataReader implements Reader
         $nodes = iterator_to_array($nodes);
 
         return array_map(
-            fn (DOMNode $node) => $this->nodeToItem($node, $xpath, $url),
+            fn (DOMNode|Node $node) => $this->nodeToItem($node, $xpath, $url),
             $nodes,
         );
     }
 
     /**
-     * Extracts information from a DOMNode into an Item.
+     * Extracts information from a (DOM)Node into an Item.
      *
-     * @param DOMNode  $node  A DOMNode representing an element with the itemscope attribute.
-     * @param DOMXPath $xpath A DOMXPath object created from the node's document element.
-     * @param string   $url   The URL the document was retrieved from, for relative URL resolution.
+     * @param DOMNode|Node   $node  A (DOM)Node representing an element with the itemscope attribute.
+     * @param DOMXPath|XPath $xpath A (DOM)XPath object created from the node's document element.
+     * @param string         $url   The URL the document was retrieved from, for relative URL resolution.
      */
-    private function nodeToItem(DOMNode $node, DOMXPath $xpath, string $url): Item
+    private function nodeToItem(DOMNode|Node $node, DOMXPath|XPath $xpath, string $url): Item
     {
         $itemid = $node->attributes->getNamedItem('itemid');
 
@@ -106,7 +116,7 @@ final class MicrodataReader implements Reader
 
         // Exclude properties that are inside a nested item; XPath does not seem to provide a way to do this.
         // See: https://stackoverflow.com/q/26365495/759866
-        $itemprops = array_filter($itemprops, function (DOMNode $itemprop) use ($node) {
+        $itemprops = array_filter($itemprops, function (DOMNode|Node $itemprop) use ($node) {
             for (; ;) {
                 $itemprop = $itemprop->parentNode;
 
@@ -122,7 +132,7 @@ final class MicrodataReader implements Reader
 
         $vocabularyIdentifier = $this->getVocabularyIdentifier($types);
 
-        /** @var DOMNode[] $itemprops */
+        /** @var array<DOMNode|Node> $itemprops */
         foreach ($itemprops as $itemprop) {
             /**
              * An element introducing a property can introduce multiple properties at once, to avoid duplication when
@@ -159,11 +169,11 @@ final class MicrodataReader implements Reader
     /**
      * @see https://www.w3.org/TR/microdata/#values
      *
-     * @param DOMNode  $node  A DOMNode representing an element with the itemprop attribute.
-     * @param DOMXPath $xpath A DOMXPath object created from the node's document element.
-     * @param string   $url   The URL the document was retrieved from, for relative URL resolution.
+     * @param DOMNode|Node   $node  A (DOM)Node representing an element with the itemprop attribute.
+     * @param DOMXPath|XPath $xpath A (DOM)XPath object created from the node's document element.
+     * @param string         $url   The URL the document was retrieved from, for relative URL resolution.
      */
-    private function getPropertyValue(DOMNode $node, DOMXPath $xpath, string $url): Item|string
+    private function getPropertyValue(DOMNode|Node $node, DOMXPath|XPath $xpath, string $url): Item|string
     {
         /**
          * If the element also has an itemscope attribute: the value is the item created by the element.

--- a/src/Reader/RdfaLiteReader.php
+++ b/src/Reader/RdfaLiteReader.php
@@ -165,7 +165,7 @@ final class RdfaLiteReader implements Reader
 
         // Exclude properties that are inside a nested item; XPath does not seem to provide a way to do this.
         // See: https://stackoverflow.com/q/26365495/759866
-        $properties = array_filter($properties, function (DOMNode $itemprop) use ($node, $xpath) {
+        $properties = array_filter($properties, function (DOMNode $itemprop) use ($node) {
             for (; ;) {
                 $itemprop = $itemprop->parentNode;
 

--- a/src/Reader/ReaderChain.php
+++ b/src/Reader/ReaderChain.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Brick\StructuredData\Reader;
 
 use Brick\StructuredData\Reader;
+use Dom\Document;
 use DOMDocument;
 use Override;
 
@@ -29,7 +30,7 @@ final class ReaderChain implements Reader
     }
 
     #[Override]
-    public function read(DOMDocument $document, string $url): array
+    public function read(Document|DOMDocument $document, string $url): array
     {
         if (! $this->readers) {
             return [];

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -59,7 +59,7 @@ class ReaderTest extends TestCase
             $jsonFile = preg_replace('/\-in\.html$/', '-out.json', $htmlFile);
             $expectedJson = rtrim(file_get_contents($jsonFile));
 
-            yield [$htmlFile, $expectedJson];
+            yield $htmlFile => [$htmlFile, $expectedJson];
         }
     }
 }


### PR DESCRIPTION
Inspired by #5, keep backward DOMDocument compatibility for PHP <8.4.
I can add a PR to `brick/schema` (to allow passing a `Dom\Document`) if accepted.