### PR TITLE
Fix: array @type parsing - iterate over $type not $types

### DIFF
--- a/src/Reader/JsonLdReader.php
+++ b/src/Reader/JsonLdReader.php
@@ -161,8 +161,8 @@ final class JsonLdReader implements Reader
                 $types = [$type];
             } elseif (is_array($type)) {
                 $types = array_map(
-                    fn ($type) => is_string($type) ? $this->resolveTerm($type, $vocabulary) : null,
-                    $types,
+                    fn ($t) => is_string($t) ? $this->resolveTerm($t, $vocabulary) : null,
+                    $type,
                 );
 
                 $types = array_filter($types);


### PR DESCRIPTION
## Summary

- Fixes bug where array-style `@type` values (e.g., `["Recipe", "NewsArticle"]`) were not being parsed
- The bug was on line 154 where `$types` (empty array) was used instead of `$type` (the actual array)

## Problem

When parsing JSON-LD with array-style `@type` like:
```json
{
  "@context": "http://schema.org",
  "@type": ["Recipe", "NewsArticle"],
  "name": "Good Old-Fashioned Pancakes"
}
```

The library would return an item with no types because line 154 iterated over `$types` (an empty array initialized on line 143) instead of `$type` (the array from the JSON).

This affects major recipe sites like AllRecipes.com which use array-style `@type` values.

## Fix

Changed line 154 from:
```php
$types,
```
to:
```php
$type,
```

Also renamed the closure parameter from `$type` to `$t` to avoid shadowing the outer `$type` variable.

## Test plan

- [x] Verified fix parses AllRecipes.com recipe pages correctly
- [x] Array-style `@type` values are now properly resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)